### PR TITLE
Support Gradle 10 configuration cache compatibility

### DIFF
--- a/gitversioner/build.gradle
+++ b/gitversioner/build.gradle
@@ -34,14 +34,18 @@ dependencies {
 
 // Task to generate Javadoc JAR
 tasks.register('javadocJar', Jar) {
-    archiveClassifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from javadoc
 }
 
 // Task to generate sources JAR
 tasks.register('sourcesJar', Jar) {
-    archiveClassifier = 'sources'
+    archiveClassifier.set('sources')
     from sourceSets.main.allSource
+}
+
+tasks.named('assemble') {
+    dependsOn tasks.named('javadocJar'), tasks.named('sourcesJar')
 }
 
 // Task to save version to resources
@@ -68,10 +72,6 @@ gradlePlugin {
     }
 
     automatedPublishing = true
-}
-
-artifacts {
-    archives javadocJar, sourcesJar
 }
 
 /*

--- a/gitversioner/src/main/java/de/sharpmind/gitversioner/AzureGitInfoExtractor.kt
+++ b/gitversioner/src/main/java/de/sharpmind/gitversioner/AzureGitInfoExtractor.kt
@@ -1,12 +1,9 @@
 package de.sharpmind.gitversioner
 
-import org.gradle.api.Project
-
 /**
  * Azure DevOps Azure Build Pipeline Git implementation of [GitInfoExtractor].
  */
-internal class AzureGitInfoExtractor(private val project: Project, delegate: GitInfoExtractor) :
-    GitInfoExtractor by delegate {
+internal class AzureGitInfoExtractor(delegate: GitInfoExtractor) : GitInfoExtractor by delegate {
     /**
      * Get the current branch name from the environment variable Build.SourceBranchName
      */

--- a/gitversioner/src/main/java/de/sharpmind/gitversioner/DisplayGitVersion.kt
+++ b/gitversioner/src/main/java/de/sharpmind/gitversioner/DisplayGitVersion.kt
@@ -1,0 +1,17 @@
+package de.sharpmind.gitversioner
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+internal abstract class DisplayGitVersion : DefaultTask() {
+
+    @get:Input
+    abstract val report: Property<String>
+
+    @TaskAction
+    fun display() {
+        logger.lifecycle(report.get())
+    }
+}

--- a/gitversioner/src/main/java/de/sharpmind/gitversioner/GenerateGitVersionName.kt
+++ b/gitversioner/src/main/java/de/sharpmind/gitversioner/GenerateGitVersionName.kt
@@ -1,42 +1,34 @@
 package de.sharpmind.gitversioner
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.Internal
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.util.Properties
 
-internal open class GenerateGitVersionName : DefaultTask() {
+internal abstract class GenerateGitVersionName : DefaultTask() {
 
-    @Internal
-    lateinit var gitVersioner: GitVersioner
+    @get:Input
+    abstract val versionProperties: MapProperty<String, String>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
 
     @TaskAction
     fun generate() {
-        val file = project.file("${project.buildDir}/gitversioner/version.properties")
+        val file = outputFile.get().asFile
         file.parentFile.mkdirs()
 
         val properties = Properties().apply {
-            with(gitVersioner) {
-                putWhenSet("versionCode", versionCode)
-                putWhenSet("versionName", versionName)
-                putWhenSet("baseBranch", baseBranch)
-                putWhenSet("branchName", branchName)
-                putWhenSet("currentSha1", currentSha1)
-                putWhenSet("baseBranchCommitCount", baseBranchCommitCount)
-                putWhenSet("featureBranchCommitCount", featureBranchCommitCount)
-                putWhenSet("timeComponent", timeComponent)
-                putWhenSet("yearFactor", yearFactor)
-                putWhenSet("localChanges", localChanges)
-            }
+            putAll(versionProperties.get())
         }
 
-        properties.store(file.writer(), "gitVersioner plugin - extracted data from git repository")
-        project.logger.lifecycle("git versionName: ${gitVersioner.versionName}")
-        project.logger.lifecycle("gitVersion output: $file")
+        file.writer().use {
+            properties.store(it, "gitVersioner plugin - extracted data from git repository")
+        }
+        logger.lifecycle("git versionName: ${versionProperties.get()["versionName"]}")
+        logger.lifecycle("gitVersion output: $file")
     }
-}
-
-private fun Properties.putWhenSet(key: String, value: Any?) {
-    if (value == null) return
-    put(key, value.toString())
 }

--- a/gitversioner/src/main/java/de/sharpmind/gitversioner/GitVersionerPlugin.kt
+++ b/gitversioner/src/main/java/de/sharpmind/gitversioner/GitVersionerPlugin.kt
@@ -35,11 +35,11 @@ public class GitVersionerPlugin : Plugin<Project> {
         }
 
         // the default git info extractor
-        val shellGitInfoExtractor = ShellGitInfoExtractor(rootProject)
+        val shellGitInfoExtractor = ShellGitInfoExtractor(rootProject.projectDir, project.providers)
 
         val gitVersionExtractor =
             // use azure git info extractor if running in azure pipelines
-            if (isRunningInAzurePipelines) AzureGitInfoExtractor(rootProject, shellGitInfoExtractor)
+            if (isRunningInAzurePipelines) AzureGitInfoExtractor(shellGitInfoExtractor)
             // use shell git info extractor as default
             else shellGitInfoExtractor
 
@@ -48,90 +48,35 @@ public class GitVersionerPlugin : Plugin<Project> {
             GitVersioner::class.java, gitVersionExtractor, project.logger
         )
 
-        project.task("gitVersion").apply {
-            group = "Help"
-            description = "Displays the version information extracted from git history"
-            doLast {
-                with(gitVersioner) {
-
-                    if (!gitVersioner.isGitProjectCorrectlyInitialized) {
-
-                        val why = if (gitVersioner.isHistoryShallowed) {
-                            "WARNING: Git history is incomplete (shallow clone)\n" +
-                                    "The de.sharpmind.gitversioner gradle plugin requires the complete git history to calculate " +
-                                    "the version. The history is shallowed, therefore the version code would be incorrect.\n" +
-                                    "Default values versionName: 'undefined', versionCode: 1 are used instead.\n\n" +
-                                    "Please fetch the complete history with:\n" +
-                                    "\tgit fetch --unshallow"
-                        } else {
-                            "WARNING: git not initialized. Run:\n" +
-                                    "\tgit init"
-                        }
-
-                        println(
-                            """
-                        |
-                        |GitVersioner Plugin v$pluginVersion
-                        |-------------------
-                        |VersionCode: $versionCode
-                        |VersionName: $versionName
-                        |
-                        |baseBranch: $baseBranch
-                        |
-                        |$why
-                        """.replaceIndentByMargin()
-                        )
-                        return@doLast
-                    }
-
-                    val baseBranchRange = (initialCommit?.take(7) ?: "") +
-                            "..${featureBranchOriginCommit?.take(7) ?: ""}"
-
-                    val featureBranchRange = (featureBranchOriginCommit?.take(7) ?: "") +
-                            "..${currentSha1Short ?: ""}"
-
-                    println(
-                        """
-                        |
-                        |GitVersioner Plugin v$pluginVersion
-                        |-------------------
-                        |VersionCode: $versionCode
-                        |VersionName: $versionName
-                        |
-                        |baseBranch: $baseBranch
-                        |current branch: $branchName
-                        |current commit: $currentSha1Short
-                        |
-                        |baseBranch commits: $baseBranchCommitCount ($baseBranchRange)
-                        |featureBranch commits: $featureBranchCommitCount ($featureBranchRange)
-                        |
-                        |timeComponent: $timeComponent (yearFactor:$yearFactor)
-                        |
-                        |LocalChanges: ${localChanges.shortStats()}
-                        """.replaceIndentByMargin()
-                    )
-                }
-            }
+        val gitVersionTask = project.tasks.register("gitVersion", DisplayGitVersion::class.java) {
+            it.group = "Help"
+            it.description = "Displays the version information extracted from git history"
         }
 
-        val task = project.tasks.create("generateGitVersionName", GenerateGitVersionName::class.java).apply {
-            this.gitVersioner = gitVersioner
+        val generateTask = project.tasks.register("generateGitVersionName", GenerateGitVersionName::class.java) {
+            it.group = "Build"
+            it.description = "analyzes the git history and creates a version name (generates machine readable output file)"
+            it.outputFile.convention(project.layout.buildDirectory.file("gitversioner/version.properties"))
+        }
 
-            group = "Build"
-            description = "analyzes the git history and creates a version name (generates machine readable output file)"
+        project.afterEvaluate {
+            val versionProperties = gitVersioner.asPropertiesMap()
+            generateTask.configure {
+                it.versionProperties.set(versionProperties)
+            }
+            gitVersionTask.configure {
+                it.report.set(gitVersioner.createReport(pluginVersion))
+            }
         }
 
         project.plugins.withType(JavaPlugin::class.java) { javaPlugin ->
             val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
             val main = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
 
-            val file = project.file("${project.buildDir}/gitversioner/version.properties")
-            val dir = file.parentFile
-            //main.resources.srcDirs.add(dir)
-            main.resources.setSrcDirs(listOf(main.resources.srcDirs, dir))
+            main.resources.srcDir(project.layout.buildDirectory.dir("gitversioner"))
 
             project.tasks.named(JavaPlugin.PROCESS_RESOURCES_TASK_NAME).configure {
-                it.dependsOn(task)
+                it.dependsOn(generateTask)
             }
         }
     }
@@ -141,4 +86,77 @@ public class GitVersionerPlugin : Plugin<Project> {
         props.load(GitVersionerPlugin::class.java.getResourceAsStream("/version.properties"))
         props.getProperty("version")
     }
+}
+
+private fun GitVersioner.asPropertiesMap(): Map<String, String> {
+    val properties = linkedMapOf<String, String>()
+    properties.putWhenSet("versionCode", versionCode)
+    properties.putWhenSet("versionName", versionName)
+    properties.putWhenSet("baseBranch", baseBranch)
+    properties.putWhenSet("branchName", branchName)
+    properties.putWhenSet("currentSha1", currentSha1)
+    properties.putWhenSet("baseBranchCommitCount", baseBranchCommitCount)
+    properties.putWhenSet("featureBranchCommitCount", featureBranchCommitCount)
+    properties.putWhenSet("timeComponent", timeComponent)
+    properties.putWhenSet("yearFactor", yearFactor)
+    properties.putWhenSet("localChanges", localChanges)
+    return properties
+}
+
+private fun MutableMap<String, String>.putWhenSet(key: String, value: Any?) {
+    if (value != null) {
+        put(key, value.toString())
+    }
+}
+
+private fun GitVersioner.createReport(pluginVersion: String): String {
+    if (!isGitProjectCorrectlyInitialized) {
+        val why = if (isHistoryShallowed) {
+            "WARNING: Git history is incomplete (shallow clone)\n" +
+                    "The de.sharpmind.gitversioner gradle plugin requires the complete git history to calculate " +
+                    "the version. The history is shallowed, therefore the version code would be incorrect.\n" +
+                    "Default values versionName: 'undefined', versionCode: 1 are used instead.\n\n" +
+                    "Please fetch the complete history with:\n" +
+                    "\tgit fetch --unshallow"
+        } else {
+            "WARNING: git not initialized. Run:\n" +
+                    "\tgit init"
+        }
+
+        return """
+            |
+            |GitVersioner Plugin v$pluginVersion
+            |-------------------
+            |VersionCode: $versionCode
+            |VersionName: $versionName
+            |
+            |baseBranch: $baseBranch
+            |
+            |$why
+        """.replaceIndentByMargin()
+    }
+
+    val baseBranchRange = (initialCommit?.take(7) ?: "") +
+            "..${featureBranchOriginCommit?.take(7) ?: ""}"
+    val featureBranchRange = (featureBranchOriginCommit?.take(7) ?: "") +
+            "..${currentSha1Short ?: ""}"
+
+    return """
+        |
+        |GitVersioner Plugin v$pluginVersion
+        |-------------------
+        |VersionCode: $versionCode
+        |VersionName: $versionName
+        |
+        |baseBranch: $baseBranch
+        |current branch: $branchName
+        |current commit: $currentSha1Short
+        |
+        |baseBranch commits: $baseBranchCommitCount ($baseBranchRange)
+        |featureBranch commits: $featureBranchCommitCount ($featureBranchRange)
+        |
+        |timeComponent: $timeComponent (yearFactor:$yearFactor)
+        |
+        |LocalChanges: ${localChanges.shortStats()}
+    """.replaceIndentByMargin()
 }

--- a/gitversioner/src/main/java/de/sharpmind/gitversioner/ShellGitInfoExtractor.kt
+++ b/gitversioner/src/main/java/de/sharpmind/gitversioner/ShellGitInfoExtractor.kt
@@ -1,9 +1,7 @@
 package de.sharpmind.gitversioner
 
 import org.gradle.api.GradleException
-import org.gradle.api.Project
-import org.gradle.api.provider.Provider
-import java.io.ByteArrayOutputStream
+import org.gradle.api.provider.ProviderFactory
 import java.io.File
 
 interface GitInfoExtractor {
@@ -21,15 +19,18 @@ interface GitInfoExtractor {
 /**
  * Executes shell commands to get information from git
  */
-internal class ShellGitInfoExtractor(private val project: Project) : GitInfoExtractor {
+internal class ShellGitInfoExtractor(
+    private val projectDir: File,
+    private val providers: ProviderFactory
+) : GitInfoExtractor {
 
     override val currentSha1: String? by lazy {
-        val sha1 = "git rev-parse HEAD".execute().get().throwOnError().text.trim()
+        val sha1 = "git rev-parse HEAD".execute().throwOnError().text.trim()
         sha1.ifEmpty { null }
     }
 
     override val currentBranch: String? by lazy {
-        when (val result = "git symbolic-ref --short -q HEAD".execute().get()) {
+        when (val result = "git symbolic-ref --short -q HEAD".execute()) {
             is ProcessResult.Success -> {
                 val branch = result.text.trim()
                 branch.ifEmpty { null }
@@ -39,7 +40,7 @@ internal class ShellGitInfoExtractor(private val project: Project) : GitInfoExtr
     }
 
     override val localChanges: LocalChanges by lazy {
-        val shortStat = "git diff HEAD --shortstat".execute().get().throwOnError().text.trim()
+        val shortStat = "git diff HEAD --shortstat".execute().throwOnError().text.trim()
         if (shortStat.isEmpty()) return@lazy NO_CHANGES
 
         return@lazy parseShortStats(shortStat)
@@ -47,14 +48,14 @@ internal class ShellGitInfoExtractor(private val project: Project) : GitInfoExtr
 
     override val initialCommitDate: Long by lazy {
         val initialCommit: String = commitsToHead.lastOrNull() ?: return@lazy 0L
-        val time = listOf("git", "log", "-n 1", "--pretty=format:'%at'", initialCommit).execute().get()
+        val time = listOf("git", "log", "-n 1", "--pretty=format:'%at'", initialCommit).execute()
             .throwOnError().text.replace("\'", "").trim()
 
         return@lazy if (time.isEmpty()) 0L else time.toLong()
     }
 
     override fun commitDate(rev: String): Long {
-        val time = listOf("git", "log", "--pretty=format:'%at'", "-n 1", rev).execute().get()
+        val time = listOf("git", "log", "--pretty=format:'%at'", "-n 1", rev).execute()
             .throwOnError().text.replace("\'", "").trim()
         return if (time.isEmpty()) 0 else time.toLong()
     }
@@ -62,7 +63,7 @@ internal class ShellGitInfoExtractor(private val project: Project) : GitInfoExtr
     override val commitsToHead: List<String> by lazy { commitsUpTo("HEAD") }
 
     override val isGitWorking: Boolean by lazy {
-        val result = "git status".execute().get()
+        val result = "git status".execute()
         if (result is ProcessResult.Error) {
             when (val exitCode = result.errorCode) {
                 69 -> {
@@ -90,7 +91,7 @@ internal class ShellGitInfoExtractor(private val project: Project) : GitInfoExtr
 
     override val isHistoryShallowed: Boolean by lazy {
         // returns root dir of git
-        val rootPath = "git rev-parse --show-toplevel".execute().get().throwOnError().text.trim()
+        val rootPath = "git rev-parse --show-toplevel".execute().throwOnError().text.trim()
         val shallowFile = File("$rootPath/.git/shallow")
 
         if (shallowFile.exists()) {
@@ -109,10 +110,10 @@ internal class ShellGitInfoExtractor(private val project: Project) : GitInfoExtr
 
     override fun commitsUpTo(rev: String, args: String): List<String> {
         val text = try {
-            "git rev-list $rev $args".execute().get().throwOnError().text
+            "git rev-list $rev $args".execute().throwOnError().text
         } catch (e: Exception) {
             try {
-                "git rev-list origin/$rev $args".execute().get().throwOnError().text
+                "git rev-list origin/$rev $args".execute().throwOnError().text
             } catch (e: Exception) {
                 ""
             }
@@ -121,27 +122,20 @@ internal class ShellGitInfoExtractor(private val project: Project) : GitInfoExtr
         return text.lines().asSequence().map { it.trim() }.filter { it.isNotBlank() }.toList()
     }
 
-    private fun String.execute(): Provider<ProcessResult> = trim().split(" ").execute()
+    private fun String.execute(): ProcessResult = trim().split(" ").execute()
 
-    private fun List<String>.execute(): Provider<ProcessResult> {
-        val out = ByteArrayOutputStream()
-        val err = ByteArrayOutputStream()
-        val process = ProcessBuilder(this@execute)
-            .directory(project.projectDir)
-            .redirectErrorStream(false)
-            .start()
-        process.outputStream.close()
-        out.write(process.inputStream.readBytes())
-        err.write(process.errorStream.readBytes())
-        val exitCode = process.waitFor()
+    private fun List<String>.execute(): ProcessResult {
+        val command = toList()
+        val output = providers.exec {
+            it.commandLine(command)
+            it.workingDir(projectDir)
+            it.isIgnoreExitValue = true
+        }
+        val exitCode = output.result.get().exitValue
         return if (exitCode == 0) {
-            project.providers.provider {
-                ProcessResult.Success(out.toString())
-            }
+            ProcessResult.Success(output.standardOutput.asText.get())
         } else {
-            project.providers.provider {
-                ProcessResult.Error(err.toString(), exitCode, this.joinToString(" "))
-            }
+            ProcessResult.Error(output.standardError.asText.get(), exitCode, command.joinToString(" "))
         }
     }
 

--- a/gitversioner/src/test/java/de/sharpmind/gitversioner/ConfigurationCacheTest.kt
+++ b/gitversioner/src/test/java/de/sharpmind/gitversioner/ConfigurationCacheTest.kt
@@ -1,0 +1,78 @@
+package de.sharpmind.gitversioner
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.Properties
+
+class ConfigurationCacheTest {
+
+    @get:Rule
+    val projectDir = TemporaryFolder()
+
+    @Test
+    fun `tasks reuse the configuration cache`() {
+        val rootDir = projectDir.root
+        rootDir.resolve("settings.gradle").writeText("rootProject.name = 'configuration-cache-test'\n")
+        rootDir.resolve("build.gradle").writeText(
+            """
+            plugins {
+                id 'java'
+                id 'de.sharpmind.gitversioner'
+            }
+            """.trimIndent()
+        )
+        rootDir.resolve(".gitignore").writeText(".gradle/\nbuild/\n")
+        rootDir.resolve("README.md").writeText("Configuration cache test project\n")
+        initializeGitRepository(rootDir)
+
+        val arguments = listOf(
+            "gitVersion",
+            "generateGitVersionName",
+            "--configuration-cache",
+            "--configuration-cache-problems=fail",
+            "--stacktrace"
+        )
+
+        val firstRun = runner(rootDir, arguments).build()
+        assertThat(firstRun.output).contains("Configuration cache entry stored.")
+
+        val secondRun = runner(rootDir, arguments).build()
+        assertThat(secondRun.output).contains("Configuration cache entry reused.")
+
+        val propertiesFile = rootDir.resolve("build/gitversioner/version.properties")
+        assertThat(propertiesFile).isFile
+        val properties = Properties().apply {
+            propertiesFile.inputStream().use(::load)
+        }
+        assertThat(properties.getProperty("versionName")).isNotBlank()
+    }
+
+    private fun runner(rootDir: File, arguments: List<String>): GradleRunner =
+        GradleRunner.create()
+            .withProjectDir(rootDir)
+            .withPluginClasspath()
+            .withArguments(arguments)
+
+    private fun initializeGitRepository(rootDir: File) {
+        runGit(rootDir, "init", "--initial-branch=main")
+        runGit(rootDir, "config", "user.name", "GitVersioner Test")
+        runGit(rootDir, "config", "user.email", "gitversioner-test@sharpmind.de")
+        runGit(rootDir, "add", ".")
+        runGit(rootDir, "commit", "-m", "Initial commit")
+    }
+
+    private fun runGit(rootDir: File, vararg arguments: String) {
+        val process = ProcessBuilder(listOf("git") + arguments)
+            .directory(rootDir)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        check(process.waitFor() == 0) {
+            "git ${arguments.joinToString(" ")} failed:\n$output"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- replace task-time Project access with declared task inputs and outputs
- execute Git commands through ProviderFactory.exec so configuration inputs are tracked
- register plugin tasks lazily and modernize deprecated archive configuration
- add a TestKit regression test that requires configuration-cache storage and reuse

## Verification

- ./gradlew check --rerun-tasks
- ./gradlew :gitversioner:check --configuration-cache --configuration-cache-problems=fail (stored and reused)
- TestKit consumer runs gitVersion and generateGitVersionName twice with configuration-cache problems treated as failures

Fixes #5